### PR TITLE
Fix URI::ToFilename return value for error handling case

### DIFF
--- a/src/common/URI.cpp
+++ b/src/common/URI.cpp
@@ -319,7 +319,7 @@ string URI::ToFilename() const
     else
         result = uriUriStringToUnixFilenameA(uri_str.c_str(), filename.GetStr());
     if (result)
-        return 0;
+        return "";
 
     return filename.GetCStr();
 }


### PR DESCRIPTION
Fixes build when compiler refuses to cast 0 int literal to std::string