### PR TITLE
Bugfix for cmake version

### DIFF
--- a/cmake/git_version_904dbda.patch
+++ b/cmake/git_version_904dbda.patch
@@ -16,8 +16,9 @@ index 55e6d07..e1ce4a0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,7 +1,11 @@
- cmake_minimum_required(VERSION 3.2)
+-cmake_minimum_required(VERSION 3.2)
 -project(cmake_git_version_tracking
++cmake_minimum_required(VERSION 3.12)
 +
 +project(${GIT_VERSION_PROJECT_PREFIX}git_version
      LANGUAGES C)

--- a/deps/libMXF/cmake/git_version_904dbda.patch
+++ b/deps/libMXF/cmake/git_version_904dbda.patch
@@ -16,8 +16,9 @@ index 55e6d07..e1ce4a0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,7 +1,11 @@
- cmake_minimum_required(VERSION 3.2)
+-cmake_minimum_required(VERSION 3.2)
 -project(cmake_git_version_tracking
++cmake_minimum_required(VERSION 3.12)
 +
 +project(${GIT_VERSION_PROJECT_PREFIX}git_version
      LANGUAGES C)

--- a/deps/libMXFpp/cmake/git_version_904dbda.patch
+++ b/deps/libMXFpp/cmake/git_version_904dbda.patch
@@ -16,8 +16,9 @@ index 55e6d07..e1ce4a0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,7 +1,11 @@
- cmake_minimum_required(VERSION 3.2)
+-cmake_minimum_required(VERSION 3.2)
 -project(cmake_git_version_tracking
++cmake_minimum_required(VERSION 3.12)
 +
 +project(${GIT_VERSION_PROJECT_PREFIX}git_version
      LANGUAGES C)


### PR DESCRIPTION
Cmake recently removed support for files using cmake_minimum_required < 3.5. This leads to the error: "Compatibility with CMake < 3.5 has been removed from CMake." Alternatively a min...max syntax is supported to signalize that later versions are fine too. However with many other files mentioning 3.12, I thought it would be easiest to unify that.