### PR TITLE
update libexpat version

### DIFF
--- a/cmake/ext_expat.cmake
+++ b/cmake/ext_expat.cmake
@@ -3,7 +3,7 @@ if(expat_link_lib)
 endif()
 
 
-if(MSVC OR BMX_BUILD_EXPAT_SOURCE)
+if(BMX_BUILD_EXPAT_SOURCE)
     include(FetchContent)
 
     set(EXPAT_BUILD_DOCS OFF CACHE INTERNAL "")
@@ -22,26 +22,16 @@ if(MSVC OR BMX_BUILD_EXPAT_SOURCE)
         )
     else()
         FetchContent_Declare(FT_libexpat
+			SOURCE_SUBDIR expat
             GIT_REPOSITORY https://github.com/libexpat/libexpat
-            GIT_TAG R_2_5_0
+            GIT_TAG R_2_8_0
         )
     endif()
 
-    # Use FetchContent_Populate because the CMakeLists.txt is in the expat/ sub-directory
-    FetchContent_GetProperties(FT_libexpat)
-    if(NOT FT_libexpat_POPULATED)
-        FetchContent_Populate(FT_libexpat)
-
-        add_subdirectory("${ft_libexpat_SOURCE_DIR}/expat" ${ft_libexpat_BINARY_DIR})
-    endif()
+    FetchContent_MakeAvailable(FT_libexpat) 
 
     set(expat_link_lib expat)
 else()
-    include(FindEXPAT)
-
-    if(NOT EXPAT_FOUND)
-        message(FATAL_ERROR "expat dependency not found")
-    endif()
-
+    find_package(EXPAT REQUIRED)
     set(expat_link_lib EXPAT::EXPAT)
 endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -41,6 +41,9 @@ if(UNIX)
 elseif(MSVC)
     # Shared library currently not supported
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build using shared libraries")
+	
+	# Option to build expat from source in deps/ or from the git repo
+	option(BMX_BUILD_EXPAT_SOURCE "Build expat from source" ON)
 
     # Option to set to use the runtime
     set(BMX_SET_MSVC_RUNTIME "MD" CACHE STRING "Set MSVC debug/release runtime to 'MD' (MultiThreadedDLL), 'MT' (MultiThreaded) or 'default' (use the default)")


### PR DESCRIPTION
I updated libexpat version mainly beacuse of CMake version compatibility, as the previous version doesn't work with CMake v4+ because of cmake min version requirement.

A few additional chages:
 - I modernized FetchContent logic with FetchContent_MakeAvailable while keeping correct source subdirectory.
 - The option BMX_BUILD_EXPAT_SOURCE is now set for MSVC to ON by default to keep old logic, but allow to use find_package even when compiling with Visual Studio. This would be useful for Conan recipe where libexpat can be consumed as a Conan dependency on all platforms.