### PR TITLE
Fix Windows Release build expat issue

### DIFF
--- a/cmake/ext_expat.cmake
+++ b/cmake/ext_expat.cmake
@@ -19,6 +19,7 @@ if(BMX_BUILD_EXPAT_SOURCE)
     if(EXISTS "${PROJECT_SOURCE_DIR}/deps/libexpat")
         FetchContent_Declare(FT_libexpat
             SOURCE_DIR "${PROJECT_SOURCE_DIR}/deps/libexpat"
+			SOURCE_SUBDIR expat
         )
     else()
         FetchContent_Declare(FT_libexpat


### PR DESCRIPTION
Release Build for windows worked after this change finally in my release build testing fork...
I believe the "build and test" github action executes windows build using cmake while the release action executes MSVC, so it appears to me that this kind of issue can currently only pop up when executing the release build.