### PR TITLE
Windows build: Suggestion for fixing a build issue with ninja generator

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -12,7 +12,6 @@ if(MSVC)
     # build generators. So adding it as a source file instead of an explicit linking option,
     # CMake should cover both cases the right way.
     set(BMX_WIN_MANIFEST_SRC "${CMAKE_CURRENT_BINARY_DIR}/bmx_windows.generated.manifest")
-    #add_link_options("/MANIFEST:EMBED" "/MANIFESTINPUT:${CMAKE_CURRENT_BINARY_DIR}/bmx_windows.generated.manifest")
 
     # /manifest file is not found when incremental is enabled (default Debug build config), so we disable it.
     add_link_options("$<$<CONFIG:Debug>:/INCREMENTAL:NO>")

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -8,7 +8,11 @@ if(MSVC)
         @ONLY
     )
 
-    add_link_options("/MANIFEST:EMBED" "/MANIFESTINPUT:${CMAKE_CURRENT_BINARY_DIR}/bmx_windows.generated.manifest")
+    # CMake generates linking and manifest handling differently between Visual Studio & ninja
+    # build generators. So adding it as a source file instead of an explicit linking option,
+    # CMake should cover both cases the right way.
+    set(BMX_WIN_MANIFEST_SRC "${CMAKE_CURRENT_BINARY_DIR}/bmx_windows.generated.manifest")
+    #add_link_options("/MANIFEST:EMBED" "/MANIFESTINPUT:${CMAKE_CURRENT_BINARY_DIR}/bmx_windows.generated.manifest")
 
     # /manifest file is not found when incremental is enabled (default Debug build config), so we disable it.
     add_link_options("$<$<CONFIG:Debug>:/INCREMENTAL:NO>")
@@ -24,6 +28,7 @@ add_subdirectory(raw2bmx)
 
 add_executable(bmxtimecode
     bmxtimecode.cpp
+    ${BMX_WIN_MANIFEST_SRC}
 )
 
 target_include_directories(bmxtimecode PRIVATE

--- a/apps/bmxparse/CMakeLists.txt
+++ b/apps/bmxparse/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(bmxparse
     bmxparse.cpp
+    ${BMX_WIN_MANIFEST_SRC}
 )
 
 target_include_directories(bmxparse PRIVATE

--- a/apps/bmxtranswrap/CMakeLists.txt
+++ b/apps/bmxtranswrap/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(bmxtranswrap
     bmxtranswrap.cpp
     MXFInputTrack.cpp
+    ${BMX_WIN_MANIFEST_SRC}
 )
 
 target_include_directories(bmxtranswrap PRIVATE

--- a/apps/mxf2raw/CMakeLists.txt
+++ b/apps/mxf2raw/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(mxf2raw
     AvidInfoOutput.cpp
     mxf2raw.cpp
     OutputFileManager.cpp
+    ${BMX_WIN_MANIFEST_SRC}
 )
 
 target_include_directories(mxf2raw PRIVATE

--- a/apps/raw2bmx/CMakeLists.txt
+++ b/apps/raw2bmx/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(raw2bmx
     raw2bmx.cpp
     RawInputTrack.cpp
+    ${BMX_WIN_MANIFEST_SRC}
 )
 
 target_include_directories(raw2bmx PRIVATE


### PR DESCRIPTION
Using the ninja generator via CMake, as conan does for Windows builds, link & manifest addition are handled differently - aka. in separate steps - compared to Visual Studio generator. It seems that the VS generator adds the manifest parameter to the link command which passes it down - thus add_link_options - but the ninja generator creates a separate direct call to mt.exe which needs the manifest passed.

So with just passing the generated file as a source file, CMake supposedly should handle both generators accordingly.

Disclaimer: This change & commit message was manually done but prepared with input from Claude Opus 4.7 as I don't run Windows nor have much experience with the build specifics on Windows.

So I hope this does indeed still work with other Windows builds directly running Visual Studio. As I said above, I don't run crap OS so can't check it myself, but at least the same patch applied to 1.7 makes the conan build work.

So here is the build error which triggered me to attempt the fix: https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-30166/2/package_build_logs/build_log_bmx_1_7_e12f988ab67c48ebbe2d9a197416d038_c81ab53d7aec4674643bcc7bed3abc5dbe54a020.txt
And now with the patch, all green: https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-30166/4/package_build_logs/build_log_bmx_1_7_cb8f9f807e7dd4fb12b61105a45592a2_9c0898c88625b265470432527a881c29db1cec84.success.txt

Conan PR with that patch: https://github.com/conan-io/conan-center-index/pull/30166