### PR TITLE
Re-enabling RDD 6 page deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,6 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           # Upload RDD-6 pages only
-          path: './meta/rdd6_xml_creator/**'
+          path: 'meta/rdd6_xml_creator/'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,8 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-
+    branches:
+      - dev-rdd6-pages
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,7 +5,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches:
-      - dev-rdd6-pages 
+      - main
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload RDD-6 pages only
           path: './meta/rdd6_xml_creator/**'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload RDD-6 pages only
+          path: './meta/rdd6_xml_creator/**'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,7 +5,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches:
-      - dev-rdd6-pages
+      - dev-rdd6-pages 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/meta/rdd6_xml_creator/README.md
+++ b/meta/rdd6_xml_creator/README.md
@@ -2,9 +2,9 @@
 
 The [SMPTE RDD 6](https://doi.org/10.5594/SMPTE.RDD6.2008) (Dolby E Audio Metadata) XML Creator is a basic HTML web page application that creates an XML file suitable for `bmxtranswrap` to embed a static RDD 6 serial bitstream in an MXF file.
 
-The [RDD 6 XML Creator](https://bbc.github.io/bmx/meta/rdd6_xml_creator/) can be found online in github.io. It can also be run locally by copying the [index.html](./index.html) and supporting directories ([css](./css) and [js](./js)) to a local file system, or by using a clone of this Git repository.
+The [RDD 6 XML Creator](https://ebu.github.io/bmx/) can be found online in github.io. It can also be run locally by copying the [index.html](./index.html) and supporting directories ([css](./css) and [js](./js)) to a local file system, or by using a clone of this Git repository.
 
-Open [RDD 6 XML Creator](https://bbc.github.io/bmx/meta/rdd6_xml_creator/) or `index.html` in a web browser and fill-in the RDD 6 metadata. Select "Save XML" to export to a local file.
+Open [RDD 6 XML Creator](https://ebu.github.io/bmx/) or `index.html` in a web browser and fill-in the RDD 6 metadata. Select "Save XML" to export to a local file.
 
 >The file name includes a hash of the file contents (`var filename = "dpp_rdd6_" + hash_djb2(rdd6_xml) + ".xml"`) and therefore files will have a different name if the contents are different.
 


### PR DESCRIPTION
Creating new GitHub Actions workflow to publish the RDD-6 metadata generator html to https://ebu.github.io/bmx/